### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/188/863/421188863.geojson
+++ b/data/421/188/863/421188863.geojson
@@ -579,6 +579,10 @@
     },
     "wof:country":"BN",
     "wof:created":1459009586,
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef1163db0cc3172d19ca14a8ad40a0c7",
     "wof:hierarchy":[
         {
@@ -589,7 +593,7 @@
         }
     ],
     "wof:id":421188863,
-    "wof:lastmodified":1566615584,
+    "wof:lastmodified":1582315533,
     "wof:name":"Bandar Seri Begawan",
     "wof:parent_id":85669487,
     "wof:placetype":"locality",

--- a/data/856/327/49/85632749.geojson
+++ b/data/856/327/49/85632749.geojson
@@ -1046,6 +1046,10 @@
     },
     "wof:country":"BN",
     "wof:country_alpha3":"BRN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"f8a59665e5b162c927703ecd89bd52e6",
     "wof:hierarchy":[
         {
@@ -1060,7 +1064,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1566615569,
+    "wof:lastmodified":1582315532,
     "wof:name":"Brunei",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.