### PR TITLE
Name updates

### DIFF
--- a/data/856/327/49/85632749.geojson
+++ b/data/856/327/49/85632749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.480364,
-    "geom:area_square_m":5921248133.870731,
+    "geom:area_square_m":5921248515.702683,
     "geom:bbox":"114.076123,4.002508,115.360519,5.049556",
     "geom:latitude":4.52306,
     "geom:longitude":114.749236,
@@ -61,6 +61,9 @@
     "name:arg_x_preferred":[
         "Brunei"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0631\u0648\u0646\u0627\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u0628\u0631\u0648\u0646\u0627\u0649"
     ],
@@ -81,6 +84,9 @@
     ],
     "name:bam_x_preferred":[
         "Burin\u025byi"
+    ],
+    "name:ban_x_preferred":[
+        "Brunei Darussalam"
     ],
     "name:bar_x_preferred":[
         "Brunei"
@@ -188,6 +194,12 @@
     "name:dan_x_variant":[
         "Brunei Darussalam"
     ],
+    "name:deu_at_x_preferred":[
+        "Brunei"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Brunei"
+    ],
     "name:deu_x_preferred":[
         "Brunei"
     ],
@@ -211,6 +223,12 @@
     ],
     "name:ell_x_variant":[
         "\u039c\u03c0\u03c1\u03bf\u03c5\u03bd\u03ad\u03b9 \u039d\u03c4\u03b1\u03c1\u03bf\u03c5\u03c3\u03b1\u03bb\u03ac\u03bc"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Brunei"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Brunei"
     ],
     "name:eng_x_preferred":[
         "Brunei"
@@ -269,6 +287,9 @@
     ],
     "name:gag_x_preferred":[
         "Bruney"
+    ],
+    "name:gcr_x_preferred":[
+        "Broun\u00e9y"
     ],
     "name:ger_x_variant":[
         "Brunei Darussalam"
@@ -561,6 +582,9 @@
     "name:nan_x_preferred":[
         "Brunei"
     ],
+    "name:nan_x_variant":[
+        "B\u00fbn-l\u00e2i"
+    ],
     "name:nap_x_preferred":[
         "Brunei"
     ],
@@ -669,6 +693,9 @@
     "name:pol_x_variant":[
         "Brunei Darussalam"
     ],
+    "name:por_br_x_preferred":[
+        "Brunei"
+    ],
     "name:por_x_preferred":[
         "Brunei"
     ],
@@ -732,6 +759,9 @@
     "name:sme_x_preferred":[
         "Brunei"
     ],
+    "name:smo_x_preferred":[
+        "Brunei"
+    ],
     "name:sna_x_preferred":[
         "Brunei"
     ],
@@ -756,6 +786,15 @@
     "name:sqi_x_variant":[
         "Brunej"
     ],
+    "name:srd_x_preferred":[
+        "Brunei"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u0440\u0443\u043d\u0435\u0458"
+    ],
+    "name:srp_el_x_preferred":[
+        "Brunej"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0458"
     ],
@@ -775,6 +814,9 @@
         "Brunei"
     ],
     "name:szl_x_preferred":[
+        "Brunei"
+    ],
+    "name:szy_x_preferred":[
         "Brunei"
     ],
     "name:tam_x_preferred":[
@@ -1065,7 +1107,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1583797293,
+    "wof:lastmodified":1587428035,
     "wof:name":"Brunei",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.