### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/585/315/3/1125853153.geojson
+++ b/data/112/585/315/3/1125853153.geojson
@@ -34,6 +34,9 @@
     "name:eng_x_preferred":[
         "Tutong"
     ],
+    "name:fas_x_preferred":[
+        "\u062a\u0648\u062a\u0648\u0646\u06af"
+    ],
     "name:fra_x_preferred":[
         "Pekan Tutong"
     ],
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":1125853153,
-    "wof:lastmodified":1636494977,
+    "wof:lastmodified":1690860263,
     "wof:name":"Tutong",
     "wof:parent_id":85669495,
     "wof:placetype":"locality",

--- a/data/112/585/316/5/1125853165.geojson
+++ b/data/112/585/316/5/1125853165.geojson
@@ -37,6 +37,9 @@
     "name:eus_x_preferred":[
         "Kuala Belait"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0627\u0644\u0627 \u0628\u0644\u06cc\u062a"
+    ],
     "name:fra_x_preferred":[
         "Kuala Belait"
     ],
@@ -88,6 +91,12 @@
     "name:swe_x_preferred":[
         "Kuala Belait"
     ],
+    "name:tam_x_preferred":[
+        "\u0b95\u0bcb\u0bb2\u0bbe \u0baa\u0bc6\u0bb2\u0bc8\u0b9f\u0bcd"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e41\u0e02\u0e27\u0e07\u0e01\u0e31\u0e27\u0e25\u0e32\u0e40\u0e1a\u0e2d\u0e44\u0e25\u0e15\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Kuala Belait"
     ],
@@ -102,6 +111,9 @@
     ],
     "name:war_x_preferred":[
         "Kuala Belait"
+    ],
+    "name:yue_x_preferred":[
+        "\u99ac\u4f86\u5955"
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u6765\u5955"
@@ -143,7 +155,7 @@
         }
     ],
     "wof:id":1125853165,
-    "wof:lastmodified":1566615585,
+    "wof:lastmodified":1690860263,
     "wof:name":"Kuala Belait",
     "wof:parent_id":85669485,
     "wof:placetype":"locality",

--- a/data/421/168/427/421168427.geojson
+++ b/data/421/168/427/421168427.geojson
@@ -22,16 +22,28 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Seria"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b8\u09c7\u09b0\u09bf\u09af\u09bc\u09be"
+    ],
     "name:ceb_x_preferred":[
         "Seria"
     ],
     "name:eng_x_preferred":[
         "Seria"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0631\u06cc\u0627"
+    ],
     "name:fin_x_preferred":[
         "Seria"
     ],
     "name:fra_x_preferred":[
+        "Seria"
+    ],
+    "name:glg_x_preferred":[
         "Seria"
     ],
     "name:ind_x_preferred":[
@@ -66,6 +78,12 @@
     ],
     "name:swe_x_preferred":[
         "Seria"
+    ],
+    "name:szl_x_preferred":[
+        "Seria"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bc6\u0bb0\u0bbf\u0baf\u0bbe"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e2d\u0e40\u0e23\u0e35\u0e22"
@@ -129,7 +147,7 @@
         }
     ],
     "wof:id":421168427,
-    "wof:lastmodified":1566615583,
+    "wof:lastmodified":1690860259,
     "wof:name":"Seria",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/170/517/421170517.geojson
+++ b/data/421/170/517/421170517.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Bokok"
     ],
+    "name:eng_x_variant":[
+        "Mukim Bokok"
+    ],
     "name:eus_x_preferred":[
         "Bokok"
     ],
@@ -45,6 +48,9 @@
     ],
     "name:msa_x_preferred":[
         "Mukim Bokok"
+    ],
+    "name:nan_x_preferred":[
+        "Bokok K\u016bn"
     ],
     "name:nld_x_preferred":[
         "Bokok"
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":421170517,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860262,
     "wof:name":"Bukok",
     "wof:parent_id":85669491,
     "wof:placetype":"county",

--- a/data/421/175/671/421175671.geojson
+++ b/data/421/175/671/421175671.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Mentiri"
     ],
+    "name:eng_x_variant":[
+        "Mukim Mentiri"
+    ],
     "name:eus_x_preferred":[
         "Mentiri"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:msa_x_preferred":[
         "Mukim Mentiri"
+    ],
+    "name:nan_x_preferred":[
+        "Mentiri K\u016bn"
     ],
     "name:nld_x_preferred":[
         "Mentiri"
@@ -100,7 +106,7 @@
         }
     ],
     "wof:id":421175671,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860261,
     "wof:name":"Mentiri",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/184/425/421184425.geojson
+++ b/data/421/184/425/421184425.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Rambai"
     ],
+    "name:eng_x_variant":[
+        "Mukim Rambai"
+    ],
     "name:eus_x_preferred":[
         "Rambai"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:msa_x_preferred":[
         "Mukim Rambai"
+    ],
+    "name:nan_x_preferred":[
+        "Rambai K\u016bn"
     ],
     "name:nld_x_preferred":[
         "Rambai"
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":421184425,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860262,
     "wof:name":"Rambai",
     "wof:parent_id":85669495,
     "wof:placetype":"county",

--- a/data/421/187/441/421187441.geojson
+++ b/data/421/187/441/421187441.geojson
@@ -17,11 +17,17 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Muara Town"
+    ],
     "name:deu_x_preferred":[
         "Muara"
     ],
     "name:eng_x_preferred":[
         "Muara"
+    ],
+    "name:eng_x_variant":[
+        "Muara Town"
     ],
     "name:fra_x_preferred":[
         "Muara"
@@ -108,7 +114,7 @@
         }
     ],
     "wof:id":421187441,
-    "wof:lastmodified":1566615584,
+    "wof:lastmodified":1690860260,
     "wof:name":"Muara",
     "wof:parent_id":85669487,
     "wof:placetype":"locality",

--- a/data/421/188/863/421188863.geojson
+++ b/data/421/188/863/421188863.geojson
@@ -31,7 +31,16 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u062f\u0631 \u0633\u0631\u064a \u0628\u0643\u0627\u0648\u0627\u0646"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0646\u062f\u0631 \u0633\u064a\u0631\u064a \u0628\u0627\u06ad\u0627\u0648\u0627\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u062f\u0631 \u0633\u0631\u0649 \u0628\u0643\u0627\u0648\u0627\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Bandar Seri Begawan"
+    ],
+    "name:aym_x_preferred":[
         "Bandar Seri Begawan"
     ],
     "name:aze_x_preferred":[
@@ -39,6 +48,9 @@
     ],
     "name:bak_x_preferred":[
         "\u0411\u0430\u043d\u0434\u0430\u0440-\u0421\u0435\u0440\u0438-\u0411\u0435\u0433\u0430\u0432\u0430\u043d"
+    ],
+    "name:ban_x_preferred":[
+        "Bandar Seri Begawan"
     ],
     "name:bcl_x_preferred":[
         "Bandar Seri Begawan"
@@ -52,6 +64,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09ac\u09a8\u09cd\u09a6\u09b0 \u09b8\u09c7\u09b0\u09bf \u09ac\u09c7\u0997\u09be\u0993\u09af\u09bc\u09be\u09a8"
+    ],
+    "name:bjn_x_preferred":[
+        "Bandar Seri Begawan"
     ],
     "name:bod_x_preferred":[
         "\u0f66\u0f72\u0f0b\u0f62\u0f72\u0f0b\u0f54\u0f7a\u0f0b\u0f40\u0f0b\u0f58\u0f5a\u0f7c\u0f0b\u0f41\u0f74\u0f42\u0f66\u0f0b\u0f42\u0fb2\u0f7c\u0f44\u0f0b\u0f41\u0fb1\u0f7a\u0f62\u0f0d"
@@ -93,6 +108,9 @@
         "Bandar Seri Begawan"
     ],
     "name:deu_x_preferred":[
+        "Bandar Seri Begawan"
+    ],
+    "name:diq_x_preferred":[
         "Bandar Seri Begawan"
     ],
     "name:ell_x_preferred":[
@@ -148,6 +166,9 @@
     ],
     "name:hat_x_preferred":[
         "Banda Seri"
+    ],
+    "name:hau_x_preferred":[
+        "Bandar Seri Begawan"
     ],
     "name:hbs_x_preferred":[
         "Bandar Seri Begawan"
@@ -215,6 +236,9 @@
     "name:kor_x_preferred":[
         "\ubc18\ub2e4\ub974\uc2a4\ub9ac\ube0c\uac00\uc644"
     ],
+    "name:krj_x_preferred":[
+        "Dakbanwa \u015ar\u012b Bhagav\u0101n"
+    ],
     "name:lat_x_preferred":[
         "Bandar Seri Begawan"
     ],
@@ -266,6 +290,9 @@
     "name:myv_x_preferred":[
         "\u0411\u0430\u043d\u0434\u0430\u0440-\u0421\u0435\u0440\u0438-\u0411\u0435\u0433\u0430\u0432\u0430\u043d"
     ],
+    "name:mzn_x_preferred":[
+        "\u0628\u0646\u062f\u0631 \u0633\u0631\u06cc \u0628\u06af\u0627\u0648\u0627\u0646"
+    ],
     "name:nah_x_preferred":[
         "Bandar Seri Begawan"
     ],
@@ -299,6 +326,9 @@
     "name:oci_x_preferred":[
         "Bandar Seri Begawan"
     ],
+    "name:olo_x_preferred":[
+        "Bandar-Seri-Begavan"
+    ],
     "name:oss_x_preferred":[
         "\u0411\u0430\u043d\u0434\u0430\u0440-\u0421\u0435\u0440\u0438-\u0411\u0435\u0433\u0430\u0432\u0430\u043d"
     ],
@@ -329,6 +359,9 @@
     "name:rus_x_preferred":[
         "\u0411\u0430\u043d\u0434\u0430\u0440-\u0421\u0435\u0440\u0438-\u0411\u0435\u0433\u0430\u0432\u0430\u043d"
     ],
+    "name:sat_x_preferred":[
+        "\u1c75\u1c5a\u1c71\u1c6b\u1c5a\u1c68 \u1c65\u1c6e\u1c68\u1c64 \u1c75\u1c6e\u1c5c\u1c5f\u1c63\u1c5f\u1c71"
+    ],
     "name:sco_x_preferred":[
         "Bandar Seri Begawan"
     ],
@@ -351,6 +384,9 @@
         "Bandar Seri Begauan"
     ],
     "name:sqi_x_variant":[
+        "Bandar Seri Begawan"
+    ],
+    "name:srd_x_preferred":[
         "Bandar Seri Begawan"
     ],
     "name:srp_x_preferred":[
@@ -386,6 +422,9 @@
     "name:tur_x_preferred":[
         "Bandar Seri Begavan"
     ],
+    "name:udm_x_preferred":[
+        "\u0411\u0430\u043d\u0434\u0430\u0440-\u0421\u0435\u0440\u0438-\u0411\u0435\u0433\u0430\u0432\u0430\u043d"
+    ],
     "name:uig_x_preferred":[
         "\u0628\u0627\u0646\u062f\u0627\u0631 \u0633\u06d5\u0631\u0649 \u0628\u06d5\u06af\u0627\u06cb\u0627\u0646"
     ],
@@ -404,6 +443,9 @@
     "name:uzb_x_preferred":[
         "Bandar-Seri-Begavan"
     ],
+    "name:vec_x_preferred":[
+        "Bandar Seri Begawan"
+    ],
     "name:vep_x_preferred":[
         "Bandar Seri Begavan"
     ],
@@ -418,6 +460,9 @@
     ],
     "name:war_x_preferred":[
         "Bandar Seri Begawan"
+    ],
+    "name:wuu_x_preferred":[
+        "\u65af\u91cc\u5df4\u52a0\u6e7e\u5e02"
     ],
     "name:xmf_x_preferred":[
         "\u10d1\u10d0\u10dc\u10d3\u10d0\u10e0-\u10e1\u10d4\u10e0\u10d8-\u10d1\u10d4\u10d2\u10d0\u10d5\u10d0\u10dc\u10d8"
@@ -595,7 +640,7 @@
         }
     ],
     "wof:id":421188863,
-    "wof:lastmodified":1607390898,
+    "wof:lastmodified":1690860261,
     "wof:name":"Bandar Seri Begawan",
     "wof:parent_id":85669487,
     "wof:placetype":"locality",

--- a/data/421/188/877/421188877.geojson
+++ b/data/421/188/877/421188877.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Lumut"
     ],
+    "name:jpn_x_preferred":[
+        "\u30eb\u30e0\u30c8"
+    ],
     "name:msa_x_preferred":[
         "Lumut"
     ],
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":421188877,
-    "wof:lastmodified":1566615584,
+    "wof:lastmodified":1690860261,
     "wof:name":"Lumut",
     "wof:parent_id":85669485,
     "wof:placetype":"locality",

--- a/data/421/189/311/421189311.geojson
+++ b/data/421/189/311/421189311.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Sengkurong"
     ],
+    "name:eng_x_variant":[
+        "Mukim Sengkurong"
+    ],
     "name:eus_x_preferred":[
         "Sengkurong"
     ],
@@ -37,6 +40,9 @@
     "name:msa_x_preferred":[
         "Mukim Sengkurong"
     ],
+    "name:nan_x_preferred":[
+        "Sengkurong K\u016bn"
+    ],
     "name:nld_x_preferred":[
         "Sengkurong"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u043d\u0433\u043a\u0443\u0440\u043e\u043d\u0433"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e21\u0e39\u0e01\u0e34\u0e21\u0e40\u0e0b\u0e34\u0e07\u0e01\u0e39\u0e23\u0e07"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u043d\u0433\u043a\u0443\u0440\u043e\u043d\u0433"
@@ -103,7 +112,7 @@
         }
     ],
     "wof:id":421189311,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860260,
     "wof:name":"Sengkurong",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/190/671/421190671.geojson
+++ b/data/421/190/671/421190671.geojson
@@ -25,14 +25,24 @@
     "name:deu_x_preferred":[
         "Berakas A"
     ],
+    "name:deu_x_variant":[
+        "Berakas"
+    ],
     "name:eng_x_preferred":[
         "Berakas"
     ],
     "name:eng_x_variant":[
-        "Berakas 'A'"
+        "Berakas 'A'",
+        "Mukim Berakas"
     ],
     "name:eus_x_preferred":[
         "Berakas A"
+    ],
+    "name:eus_x_variant":[
+        "Berakas"
+    ],
+    "name:fas_x_preferred":[
+        "\u0628\u0631\u0627\u06a9\u0627\u0633 \u0627\u06cc"
     ],
     "name:fra_x_preferred":[
         "Mukim Berakas A"
@@ -43,14 +53,29 @@
     "name:msa_x_preferred":[
         "Mukim Berakas 'A'"
     ],
+    "name:msa_x_variant":[
+        "Mukim Berakas"
+    ],
+    "name:nan_x_preferred":[
+        "Berakas A K\u016bn"
+    ],
     "name:nld_x_preferred":[
         "Berakas A"
+    ],
+    "name:nld_x_variant":[
+        "Berakas"
     ],
     "name:por_x_preferred":[
         "Berakas \"A\""
     ],
+    "name:por_x_variant":[
+        "Berakas"
+    ],
     "name:ukr_x_preferred":[
         "\u0411\u0435\u0440\u0430\u043a\u0430\u0441 A"
+    ],
+    "name:ukr_x_variant":[
+        "\u0411\u0435\u0440\u0430\u043a\u0430\u0441"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -106,7 +131,7 @@
         }
     ],
     "wof:id":421190671,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860262,
     "wof:name":"Berakas A",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/190/673/421190673.geojson
+++ b/data/421/190/673/421190673.geojson
@@ -31,6 +31,9 @@
     "name:fra_x_preferred":[
         "Kota Batu"
     ],
+    "name:ind_x_preferred":[
+        "Kota Batu"
+    ],
     "name:nld_x_preferred":[
         "Kota Batu"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421190673,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860261,
     "wof:name":"Kota Batu",
     "wof:parent_id":85675177,
     "wof:placetype":"county",

--- a/data/421/193/111/421193111.geojson
+++ b/data/421/193/111/421193111.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Kilanas"
     ],
+    "name:eng_x_variant":[
+        "Mukim Kilanas"
+    ],
     "name:eus_x_preferred":[
         "Kilanas"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:msa_x_preferred":[
         "Mukim Kilanas"
+    ],
+    "name:nan_x_preferred":[
+        "Kilanas K\u016bn"
     ],
     "name:nld_x_preferred":[
         "Kilanas"
@@ -103,7 +109,7 @@
         }
     ],
     "wof:id":421193111,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1690860259,
     "wof:name":"Kilanas",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/195/157/421195157.geojson
+++ b/data/421/195/157/421195157.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Jerudong"
     ],
+    "name:eng_x_variant":[
+        "Kampong Jerudong"
+    ],
     "name:fra_x_preferred":[
         "Jerudong"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u0436\u0435\u0440\u0443\u0434\u043e\u043d\u0433"
+    ],
+    "name:zho_x_preferred":[
+        "\u5091\u9b6f\u6771"
     ],
     "qs:gn_country":"BN",
     "qs:gn_fcode":"PPL",
@@ -85,7 +91,7 @@
         }
     ],
     "wof:id":421195157,
-    "wof:lastmodified":1566615583,
+    "wof:lastmodified":1690860259,
     "wof:name":"Kampong Jerudong",
     "wof:parent_id":85669487,
     "wof:placetype":"locality",

--- a/data/421/199/945/421199945.geojson
+++ b/data/421/199/945/421199945.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Jerudong"
     ],
+    "name:eng_x_variant":[
+        "Kampong Jerudong"
+    ],
     "name:fra_x_preferred":[
         "Jerudong"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0414\u0436\u0435\u0440\u0443\u0434\u043e\u043d\u0433"
+    ],
+    "name:zho_x_preferred":[
+        "\u5091\u9b6f\u6771"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -80,7 +86,7 @@
         }
     ],
     "wof:id":421199945,
-    "wof:lastmodified":1566615585,
+    "wof:lastmodified":1690860262,
     "wof:name":"Jerudong",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/203/819/421203819.geojson
+++ b/data/421/203/819/421203819.geojson
@@ -23,11 +23,17 @@
     "name:eng_x_preferred":[
         "Bangar"
     ],
+    "name:eng_x_variant":[
+        "Bangar Town"
+    ],
     "name:fra_x_preferred":[
         "Bangar"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05d0\u05e0\u05d2\u05d0\u05e8"
+    ],
+    "name:hye_x_preferred":[
+        "\u0532\u0561\u0576\u0563\u0561\u0580"
     ],
     "name:ind_x_preferred":[
         "Bangar"
@@ -46,6 +52,9 @@
     ],
     "name:msa_x_preferred":[
         "Bangar"
+    ],
+    "name:msa_x_variant":[
+        "Pekan Bangar"
     ],
     "name:nau_x_preferred":[
         "Bangar"
@@ -129,7 +138,7 @@
         }
     ],
     "wof:id":421203819,
-    "wof:lastmodified":1566615583,
+    "wof:lastmodified":1690860260,
     "wof:name":"Bangar",
     "wof:parent_id":85669491,
     "wof:placetype":"locality",

--- a/data/421/203/823/421203823.geojson
+++ b/data/421/203/823/421203823.geojson
@@ -17,16 +17,28 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Seria"
+    ],
+    "name:ben_x_preferred":[
+        "\u09b8\u09c7\u09b0\u09bf\u09af\u09bc\u09be"
+    ],
     "name:ceb_x_preferred":[
         "Seria"
     ],
     "name:eng_x_preferred":[
         "Seria"
     ],
+    "name:fas_x_preferred":[
+        "\u0633\u0631\u06cc\u0627"
+    ],
     "name:fin_x_preferred":[
         "Seria"
     ],
     "name:fra_x_preferred":[
+        "Seria"
+    ],
+    "name:glg_x_preferred":[
         "Seria"
     ],
     "name:ind_x_preferred":[
@@ -64,6 +76,12 @@
     ],
     "name:swe_x_preferred":[
         "Seria"
+    ],
+    "name:szl_x_preferred":[
+        "Seria"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bc6\u0bb0\u0bbf\u0baf\u0bbe"
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e2d\u0e40\u0e23\u0e35\u0e22"
@@ -118,7 +136,7 @@
         }
     ],
     "wof:id":421203823,
-    "wof:lastmodified":1566615583,
+    "wof:lastmodified":1690860260,
     "wof:name":"Seria",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/204/323/421204323.geojson
+++ b/data/421/204/323/421204323.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"114.186401,4.5845645,114.186401,4.5845645",
+    "geom:bbox":"114.186401,4.584564,114.186401,4.584564",
     "geom:latitude":4.584564,
     "geom:longitude":114.186401,
     "iso:country":"BN",
@@ -36,6 +36,9 @@
     ],
     "name:eus_x_preferred":[
         "Kuala Belait"
+    ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0627\u0644\u0627 \u0628\u0644\u06cc\u062a"
     ],
     "name:fra_x_preferred":[
         "Kuala Belait"
@@ -85,6 +88,12 @@
     "name:swe_x_preferred":[
         "Kuala Belait"
     ],
+    "name:tam_x_preferred":[
+        "\u0b95\u0bcb\u0bb2\u0bbe \u0baa\u0bc6\u0bb2\u0bc8\u0b9f\u0bcd"
+    ],
+    "name:tha_x_preferred":[
+        "\u0e41\u0e02\u0e27\u0e07\u0e01\u0e31\u0e27\u0e25\u0e32\u0e40\u0e1a\u0e2d\u0e44\u0e25\u0e15\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Kuala Belait"
     ],
@@ -96,6 +105,9 @@
     ],
     "name:war_x_preferred":[
         "Kuala Belait"
+    ],
+    "name:yue_x_preferred":[
+        "\u99ac\u4f86\u5955"
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u6765\u5955"
@@ -144,7 +156,7 @@
     },
     "wof:country":"BN",
     "wof:created":1459010181,
-    "wof:geomhash":"0c0ed80081778bb74cd971ac15c7ee7c",
+    "wof:geomhash":"cb01519ea04ee367ec27647477970e24",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +166,7 @@
         }
     ],
     "wof:id":421204323,
-    "wof:lastmodified":1566615583,
+    "wof:lastmodified":1690860259,
     "wof:name":"Kuala Belait",
     "wof:parent_id":85669485,
     "wof:placetype":"county",
@@ -167,9 +179,9 @@
 },
   "bbox": [
     114.186401,
-    4.5845645,
+    4.584564,
     114.186401,
-    4.5845645
+    4.584564
 ],
-  "geometry": {"coordinates":[114.186401,4.5845645],"type":"Point"}
+  "geometry": {"coordinates":[114.186401,4.584564],"type":"Point"}
 }

--- a/data/856/327/49/85632749.geojson
+++ b/data/856/327/49/85632749.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0411\u0440\u0443\u043d\u0435\u0438"
+    ],
     "name:ace_x_preferred":[
         "Brunai"
     ],
@@ -40,6 +43,9 @@
     "name:aka_x_preferred":[
         "Brunae"
     ],
+    "name:aka_x_variant":[
+        "Brunei"
+    ],
     "name:als_x_preferred":[
         "Brunei"
     ],
@@ -49,8 +55,14 @@
     "name:amh_x_variant":[
         "\u1265\u1229\u1292"
     ],
+    "name:ami_x_preferred":[
+        "Brunei"
+    ],
     "name:ang_x_preferred":[
         "Brunei"
+    ],
+    "name:anp_x_preferred":[
+        "\u092c\u094d\u0930\u0942\u0928\u0947\u0908"
     ],
     "name:ara_x_preferred":[
         "\u0628\u0631\u0648\u0646\u0627\u064a"
@@ -72,6 +84,9 @@
     ],
     "name:ast_x_preferred":[
         "Brun\u00e9i"
+    ],
+    "name:awa_x_preferred":[
+        "\u092c\u094d\u0930\u0941\u0928\u093e\u0908"
     ],
     "name:azb_x_preferred":[
         "\u0628\u0631\u0648\u0646\u0626\u06cc"
@@ -112,6 +127,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092c\u094d\u0930\u0941\u0928\u0947\u0908"
+    ],
+    "name:bis_x_preferred":[
+        "Brunae"
     ],
     "name:bjn_x_preferred":[
         "Brunai"
@@ -167,6 +185,9 @@
     "name:che_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0439"
     ],
+    "name:chr_x_preferred":[
+        "\u13ca\u13be\u13a2"
+    ],
     "name:chv_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0439"
     ],
@@ -175,6 +196,9 @@
     ],
     "name:cor_x_preferred":[
         "Bruney"
+    ],
+    "name:cos_x_preferred":[
+        "Brunei"
     ],
     "name:crh_x_preferred":[
         "Bruney"
@@ -187,6 +211,9 @@
     ],
     "name:cze_x_variant":[
         "Brunej Darussalam"
+    ],
+    "name:dag_x_preferred":[
+        "Brunei"
     ],
     "name:dan_x_preferred":[
         "Brunei"
@@ -312,6 +339,9 @@
     "name:gor_x_preferred":[
         "Brunei Darussalam"
     ],
+    "name:gpe_x_preferred":[
+        "Brunei"
+    ],
     "name:grn_x_preferred":[
         "Mburun\u00e9i"
     ],
@@ -375,6 +405,9 @@
     "name:hye_x_preferred":[
         "\u0532\u0580\u0578\u0582\u0576\u0565\u0575"
     ],
+    "name:hyw_x_preferred":[
+        "\u054a\u0580\u0578\u0582\u0576\u0567\u0575"
+    ],
     "name:ido_x_preferred":[
         "Brunei"
     ],
@@ -409,7 +442,8 @@
         "Brun\u00e9i Darussalam"
     ],
     "name:jav_x_variant":[
-        "Brunei"
+        "Brunei",
+        "Brun\u00e9i"
     ],
     "name:jpn_x_preferred":[
         "\u30d6\u30eb\u30cd\u30a4"
@@ -431,6 +465,9 @@
     ],
     "name:kan_x_variant":[
         "\u0cac\u0ccd\u0cb0\u0cc2\u0ca8\u0cbf"
+    ],
+    "name:kas_x_preferred":[
+        "\u0628\u0631\u065b\u0648\u0646\u0649"
     ],
     "name:kat_x_preferred":[
         "\u10d1\u10e0\u10e3\u10dc\u10d4\u10d8"
@@ -501,6 +538,9 @@
     "name:lit_x_preferred":[
         "Brun\u0117jus"
     ],
+    "name:lld_x_preferred":[
+        "Brunei"
+    ],
     "name:lmo_x_preferred":[
         "Brunei"
     ],
@@ -522,6 +562,9 @@
     "name:lzh_x_preferred":[
         "\u6c76\u840a"
     ],
+    "name:mad_x_preferred":[
+        "Brunei"
+    ],
     "name:mai_x_preferred":[
         "\u092c\u094d\u0930\u0941\u0928\u0947\u0908"
     ],
@@ -533,6 +576,9 @@
     ],
     "name:mar_x_preferred":[
         "\u092c\u094d\u0930\u0941\u0928\u0947\u0908"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0411\u0440\u0443\u043d\u0435\u0439"
     ],
     "name:min_x_preferred":[
         "Brunei"
@@ -551,6 +597,12 @@
     ],
     "name:mlt_x_preferred":[
         "Brunej"
+    ],
+    "name:mlt_x_variant":[
+        "Brunei"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd5\uabed\uabd4\uabe8\uabc5\uabe9"
     ],
     "name:mon_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0439"
@@ -609,6 +661,9 @@
     "name:new_x_preferred":[
         "\u092c\u094d\u0930\u0941\u0928\u093e\u0907"
     ],
+    "name:nia_x_preferred":[
+        "Brunei Darussalam"
+    ],
     "name:nld_x_preferred":[
         "Brunei"
     ],
@@ -664,7 +719,8 @@
         "\u0a2c\u0a30\u0a42\u0a28\u0a3e\u0a08"
     ],
     "name:pan_x_variant":[
-        "\u0a2c\u0a30\u0a41\u0a28\u0a47\u0a08"
+        "\u0a2c\u0a30\u0a41\u0a28\u0a47\u0a08",
+        "\u0a2c\u0a30\u0a42\u0a28\u0a47\u0a08"
     ],
     "name:pap_x_preferred":[
         "Brunei"
@@ -738,6 +794,9 @@
     "name:sat_x_preferred":[
         "\u1c75\u1c68\u1c69\u1c71\u1c5f\u1c6d"
     ],
+    "name:sat_x_variant":[
+        "\u1c75\u1c68\u1c69\u1c71\u1c6e\u1c6d"
+    ],
     "name:scn_x_preferred":[
         "Brunei"
     ],
@@ -746,6 +805,9 @@
     ],
     "name:sgs_x_preferred":[
         "Bruniejos"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1015\u101b\u1030\u1087\u107c\u1062\u1086\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0db6\u0df2\u0db1\u0dcf\u0dba\u0dd2"
@@ -759,7 +821,13 @@
     "name:sme_x_preferred":[
         "Brunei"
     ],
+    "name:smn_x_preferred":[
+        "Brunei"
+    ],
     "name:smo_x_preferred":[
+        "Brunei"
+    ],
+    "name:sms_x_preferred":[
         "Brunei"
     ],
     "name:sna_x_preferred":[
@@ -828,6 +896,9 @@
     "name:tat_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0439"
     ],
+    "name:tay_x_preferred":[
+        "Brunei"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c4d\u0c30\u0c42\u0c28\u0c48"
     ],
@@ -860,6 +931,9 @@
     ],
     "name:tpi_x_preferred":[
         "Brunai"
+    ],
+    "name:trv_x_preferred":[
+        "Brunei"
     ],
     "name:tso_x_preferred":[
         "Brunei"
@@ -1172,7 +1246,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1617827387,
+    "wof:lastmodified":1690860258,
     "wof:name":"Brunei",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/694/85/85669485.geojson
+++ b/data/856/694/85/85669485.geojson
@@ -41,6 +41,9 @@
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09b2\u09be\u09a4\u09bf \u099c\u09c7\u09b2\u09be"
     ],
+    "name:ben_x_variant":[
+        "\u09ac\u09c7\u09b2\u09be\u0987\u09a4 \u099c\u09c7\u09b2\u09be"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0435\u043b\u0430\u0439\u0442"
     ],
@@ -69,6 +72,9 @@
     "name:eus_x_preferred":[
         "Belait barrutia"
     ],
+    "name:eus_x_variant":[
+        "Belait"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0628\u0644\u0627\u0626\u06cc\u062a"
     ],
@@ -96,8 +102,14 @@
     "name:hun_x_preferred":[
         "Belait"
     ],
+    "name:hyw_x_preferred":[
+        "\u054a\u0565\u056c\u0561\u0575\u056b"
+    ],
     "name:ind_x_preferred":[
         "Distrik Belait"
+    ],
+    "name:ind_x_variant":[
+        "Daerah Belait"
     ],
     "name:ita_x_preferred":[
         "distretto di Belait"
@@ -182,6 +194,9 @@
     ],
     "name:war_x_preferred":[
         "Belait"
+    ],
+    "name:yue_x_preferred":[
+        "\u99ac\u4f86\u5955\u7e23"
     ],
     "name:zho_x_preferred":[
         "\u9a6c\u6765\u5955\u53bf"
@@ -304,7 +319,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1636494977,
+    "wof:lastmodified":1690860258,
     "wof:name":"Belait",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/87/85669487.geojson
+++ b/data/856/694/87/85669487.geojson
@@ -44,6 +44,9 @@
     "name:ben_x_preferred":[
         "\u09ac\u09cd\u09b0\u09c1\u09a8\u09c7\u0987 \u09ae\u09cb\u09af\u09bc\u09be\u09b0\u09be \u099c\u09c7\u09b2\u09be"
     ],
+    "name:ben_x_variant":[
+        "\u09ac\u09cd\u09b0\u09c1\u09a8\u09be\u0987-\u09ae\u09c1\u09af\u09bc\u09be\u09b0\u09be \u099c\u09c7\u09b2\u09be"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0440\u0443\u043d\u0435\u0439-\u041c\u0443\u0430\u0440\u0430"
     ],
@@ -77,6 +80,9 @@
     "name:eus_x_preferred":[
         "Brunei eta Muara"
     ],
+    "name:eus_x_variant":[
+        "Brunei-Muara"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u0628\u0631\u0648\u0646\u0626\u06cc-\u0645\u0648\u0622\u0631\u0627"
     ],
@@ -104,8 +110,14 @@
     "name:hun_x_preferred":[
         "Brunei \u00e9s Muara"
     ],
+    "name:hyw_x_preferred":[
+        "\u054a\u0580\u0578\u0582\u0576\u0567\u0575-\u0544\u0578\u0582\u0561\u0580\u0561"
+    ],
     "name:ind_x_preferred":[
         "Distrik Brunei-Muara"
+    ],
+    "name:ind_x_variant":[
+        "Daerah Brunei-Muara"
     ],
     "name:ita_x_preferred":[
         "distretto di Brunei-Muara"
@@ -177,6 +189,9 @@
     "name:tel_x_preferred":[
         "\u0c2c\u0c4d\u0c30\u0c42\u0c28\u0c40-\u0c2e\u0c41\u0c35\u0c3e\u0c30\u0c3e \u0c1c\u0c3f\u0c32\u0c4d\u0c32\u0c3e"
     ],
+    "name:tgl_x_preferred":[
+        "Distrito ng Brunei-Muara"
+    ],
     "name:tha_x_preferred":[
         "\u0e40\u0e02\u0e15\u0e1a\u0e23\u0e39\u0e44\u0e19-\u0e21\u0e31\u0e27\u0e23\u0e32"
     ],
@@ -197,6 +212,9 @@
     ],
     "name:war_x_preferred":[
         "Brunei-Muara"
+    ],
+    "name:yue_x_preferred":[
+        "\u6469\u62c9\u7e23"
     ],
     "name:zho_x_preferred":[
         "\u6c76\u83b1\u6469\u62c9\u53bf"
@@ -318,7 +336,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1636494977,
+    "wof:lastmodified":1690860257,
     "wof:name":"Brunei and Muara",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/91/85669491.geojson
+++ b/data/856/694/91/85669491.geojson
@@ -44,6 +44,9 @@
     "name:ben_x_preferred":[
         "\u099f\u09c7\u09ae\u09cd\u09ac\u09c1\u09b0\u09be\u0982 \u099c\u09c7\u09b2\u09be"
     ],
+    "name:ben_x_variant":[
+        "\u09a4\u09c7\u09ae\u09cd\u09ac\u09c1\u09b0\u0982 \u099c\u09c7\u09b2\u09be"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0435\u043c\u0431\u0443\u0440\u043e\u043d\u0433"
     ],
@@ -75,6 +78,9 @@
     "name:eus_x_preferred":[
         "Temburong barrutia"
     ],
+    "name:eus_x_variant":[
+        "Temburong"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0633\u062a\u0627\u0646 \u062a\u0645\u0628\u0648\u0631\u0648\u0646\u06af"
     ],
@@ -99,8 +105,17 @@
     "name:hin_x_preferred":[
         "\u091f\u0947\u092e\u094d\u092c\u094d\u092f\u0941\u0930\u094b\u0902\u0917 \u091c\u093f\u0932\u093e"
     ],
+    "name:hun_x_preferred":[
+        "Temburong"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0539\u0565\u057a\u0578\u0582\u0580\u0578\u0576\u056f"
+    ],
     "name:ind_x_preferred":[
         "Distrik Temburong"
+    ],
+    "name:ind_x_variant":[
+        "Daerah Temburong"
     ],
     "name:ita_x_preferred":[
         "distretto di Temburong"
@@ -162,6 +177,9 @@
     "name:swe_x_preferred":[
         "Temburong District"
     ],
+    "name:swe_x_variant":[
+        "Temburong"
+    ],
     "name:tam_x_preferred":[
         "\u0b9f\u0bc6\u0bae\u0bcd\u0baa\u0bc1\u0bb0\u0bcb\u0b99\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0bb5\u0b9f\u0bcd\u0b9f\u0bae\u0bcd"
     ],
@@ -185,6 +203,9 @@
     ],
     "name:war_x_preferred":[
         "Temburong"
+    ],
+    "name:yue_x_preferred":[
+        "\u6de1\u5e03\u9686\u7e23"
     ],
     "name:zho_x_preferred":[
         "\u6de1\u5e03\u9686\u53bf"
@@ -307,7 +328,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1614893043,
+    "wof:lastmodified":1690860258,
     "wof:name":"Temburong",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/95/85669495.geojson
+++ b/data/856/694/95/85669495.geojson
@@ -41,6 +41,9 @@
     "name:ben_x_preferred":[
         "\u09a4\u09c1\u09a4\u0982 \u099c\u09c7\u09b2\u09be"
     ],
+    "name:ben_x_variant":[
+        "\u099f\u09c1\u099f\u0982 \u099c\u09c7\u09b2\u09be"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0443\u0442\u043e\u043d\u0433"
     ],
@@ -69,6 +72,9 @@
     "name:eus_x_preferred":[
         "Tutong barrutia"
     ],
+    "name:eus_x_variant":[
+        "Tutong"
+    ],
     "name:fas_x_preferred":[
         "\u0645\u0646\u0637\u0642\u0647 \u062a\u0648\u062a\u0646\u06af"
     ],
@@ -76,6 +82,9 @@
         "Tutong"
     ],
     "name:fra_x_preferred":[
+        "Tutong"
+    ],
+    "name:frr_x_preferred":[
         "Tutong"
     ],
     "name:glg_x_preferred":[
@@ -93,8 +102,14 @@
     "name:hun_x_preferred":[
         "Tutong"
     ],
+    "name:hyw_x_preferred":[
+        "\u0539\u0578\u0582\u0569\u0578\u0576\u056f"
+    ],
     "name:ind_x_preferred":[
         "Distrik Tutong"
+    ],
+    "name:ind_x_variant":[
+        "Tutong"
     ],
     "name:ita_x_preferred":[
         "distretto di Tutong"
@@ -182,6 +197,9 @@
     ],
     "name:war_x_preferred":[
         "Tutong"
+    ],
+    "name:yue_x_preferred":[
+        "\u90fd\u6771\u7e23"
     ],
     "name:zho_x_preferred":[
         "\u90fd\u4e1c\u53bf"
@@ -304,7 +322,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1636494976,
+    "wof:lastmodified":1690860257,
     "wof:name":"Tutong",
     "wof:parent_id":85632749,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.