### PR TITLE
bn concordances, placetype local, and more

### DIFF
--- a/data/421/168/427/421168427.geojson
+++ b/data/421/168/427/421168427.geojson
@@ -137,9 +137,10 @@
         "qs_pg:id":1112149,
         "wd:id":"Q2159472"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459008764,
-    "wof:geomhash":"86c5f75edfae17d401d01e60e30aa6d3",
+    "wof:geomhash":"6f3637d8c5db18decaa04ccbec3801d8",
     "wof:hierarchy":[
         {
             "country_id":85632749,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421168427,
-    "wof:lastmodified":1690860259,
+    "wof:lastmodified":1695886920,
     "wof:name":"Seria",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/170/517/421170517.geojson
+++ b/data/421/170/517/421170517.geojson
@@ -106,9 +106,10 @@
         "qs_pg:id":1191477,
         "wd:id":"Q2491114"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459008856,
-    "wof:geomhash":"1188a3577997d26eba4c2e18adc64797",
+    "wof:geomhash":"22f64c04c1c019e12c620bcd83bfede9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421170517,
-    "wof:lastmodified":1690860262,
+    "wof:lastmodified":1695886182,
     "wof:name":"Bukok",
     "wof:parent_id":85669491,
     "wof:placetype":"county",

--- a/data/421/175/671/421175671.geojson
+++ b/data/421/175/671/421175671.geojson
@@ -94,9 +94,10 @@
         "qs_pg:id":1026937,
         "wd:id":"Q2365615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009075,
-    "wof:geomhash":"7f6a0decaa1c2fd7c54fbcbd3384c4cf",
+    "wof:geomhash":"a996a04b25f9b2f34346323112457bda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421175671,
-    "wof:lastmodified":1690860261,
+    "wof:lastmodified":1695886183,
     "wof:name":"Mentiri",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/183/167/421183167.geojson
+++ b/data/421/183/167/421183167.geojson
@@ -93,9 +93,10 @@
         "hasc:id":"BN.BE.LI",
         "qs_pg:id":792771
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009360,
-    "wof:geomhash":"d129eb672b3d0fc7d2d0e6290e5d09b8",
+    "wof:geomhash":"360bae0307af021276757bf583ed67de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421183167,
-    "wof:lastmodified":1566615585,
+    "wof:lastmodified":1695886921,
     "wof:name":"Liang",
     "wof:parent_id":85669485,
     "wof:placetype":"county",

--- a/data/421/184/425/421184425.geojson
+++ b/data/421/184/425/421184425.geojson
@@ -103,9 +103,10 @@
         "qs_pg:id":996367,
         "wd:id":"Q2704145"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009410,
-    "wof:geomhash":"b670e46c11d189b0380a3bb6a3705f76",
+    "wof:geomhash":"0007fd66f6706eccdede2cc384afba3e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":421184425,
-    "wof:lastmodified":1690860262,
+    "wof:lastmodified":1695886183,
     "wof:name":"Rambai",
     "wof:parent_id":85669495,
     "wof:placetype":"county",

--- a/data/421/184/653/421184653.geojson
+++ b/data/421/184/653/421184653.geojson
@@ -66,9 +66,10 @@
         "hasc:id":"BN.TU.KE",
         "qs_pg:id":1002807
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009418,
-    "wof:geomhash":"f415cd76530c99502c2d2e6b4b84673c",
+    "wof:geomhash":"14536d05e0704fc32ee33d69697c6720",
     "wof:hierarchy":[
         {
             "country_id":85632749,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":421184653,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1695886183,
     "wof:name":"Keriam",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/189/311/421189311.geojson
+++ b/data/421/189/311/421189311.geojson
@@ -100,9 +100,10 @@
         "qs_pg:id":1112147,
         "wd:id":"Q2490410"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009617,
-    "wof:geomhash":"96f4c3d5d45d3f2d29b3424540f10ed6",
+    "wof:geomhash":"acf015e7bfe1099317bbfbecd8cb439e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421189311,
-    "wof:lastmodified":1690860260,
+    "wof:lastmodified":1695886183,
     "wof:name":"Sengkurong",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/190/671/421190671.geojson
+++ b/data/421/190/671/421190671.geojson
@@ -119,9 +119,10 @@
         "qs_pg:id":1120024,
         "wd:id":"Q1952924"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009665,
-    "wof:geomhash":"41bbc5509037b70f92be800f3376d25e",
+    "wof:geomhash":"8582d065caca86d6b4f8380816ba8353",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421190671,
-    "wof:lastmodified":1690860262,
+    "wof:lastmodified":1695886183,
     "wof:name":"Berakas A",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/190/673/421190673.geojson
+++ b/data/421/190/673/421190673.geojson
@@ -76,7 +76,7 @@
     },
     "wof:country":"BN",
     "wof:created":1459009665,
-    "wof:geomhash":"ea8ced5bf9507d30f665227c0c5d284e",
+    "wof:geomhash":"83fcf5b75ced368f74de93ecaa5d314e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +86,7 @@
         }
     ],
     "wof:id":421190673,
-    "wof:lastmodified":1690860261,
+    "wof:lastmodified":1695887511,
     "wof:name":"Kota Batu",
     "wof:parent_id":85675177,
     "wof:placetype":"county",

--- a/data/421/190/675/421190675.geojson
+++ b/data/421/190/675/421190675.geojson
@@ -86,9 +86,10 @@
         "hasc:id":"BN.TE.AM",
         "qs_pg:id":1120026
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009665,
-    "wof:geomhash":"d5e6743e4fc3b7a28bf2cc0ebefbb2aa",
+    "wof:geomhash":"b6faf241522cbacd34eb9bab88c12fb0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":421190675,
-    "wof:lastmodified":1627521600,
+    "wof:lastmodified":1695886183,
     "wof:name":"Amo",
     "wof:parent_id":85669491,
     "wof:placetype":"county",

--- a/data/421/193/111/421193111.geojson
+++ b/data/421/193/111/421193111.geojson
@@ -97,9 +97,10 @@
         "qs_pg:id":1112150,
         "wd:id":"Q2365651"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009760,
-    "wof:geomhash":"ee2ce67d97e8264cfeadda0cdc3e7228",
+    "wof:geomhash":"32dd289350dd99d83bd3f3f8adbafdf3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421193111,
-    "wof:lastmodified":1690860259,
+    "wof:lastmodified":1695886183,
     "wof:name":"Kilanas",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/198/773/421198773.geojson
+++ b/data/421/198/773/421198773.geojson
@@ -69,9 +69,10 @@
         "hasc:id":"BN.BM.GA",
         "qs_pg:id":1112151
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459009960,
-    "wof:geomhash":"17f3bb13d5b10716207d6073259de1e7",
+    "wof:geomhash":"dd34d76a8056e73b99598cd651563959",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":421198773,
-    "wof:lastmodified":1566615584,
+    "wof:lastmodified":1695886920,
     "wof:name":"Gadong",
     "wof:parent_id":85669487,
     "wof:placetype":"county",

--- a/data/421/204/323/421204323.geojson
+++ b/data/421/204/323/421204323.geojson
@@ -154,9 +154,10 @@
         "qs_pg:id":239149,
         "wd:id":"Q588045"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BN",
     "wof:created":1459010181,
-    "wof:geomhash":"cb01519ea04ee367ec27647477970e24",
+    "wof:geomhash":"e9e38a8ffa3b9c218514d146e5133725",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421204323,
-    "wof:lastmodified":1690860259,
+    "wof:lastmodified":1695886920,
     "wof:name":"Kuala Belait",
     "wof:parent_id":85669485,
     "wof:placetype":"county",

--- a/data/856/327/49/85632749.geojson
+++ b/data/856/327/49/85632749.geojson
@@ -1216,6 +1216,7 @@
         "hasc:id":"BN",
         "icao:code":"V8",
         "ioc:id":"BRU",
+        "iso:code":"BN",
         "itu:id":"BRU",
         "loc:id":"n81131874",
         "m49:code":"096",
@@ -1230,6 +1231,7 @@
         "wk:page":"Brunei",
         "wmo:id":"BD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BN",
     "wof:country_alpha3":"BRN",
     "wof:geom_alt":[
@@ -1250,7 +1252,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1694639504,
+    "wof:lastmodified":1695881158,
     "wof:name":"Brunei",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/694/85/85669485.geojson
+++ b/data/856/694/85/85669485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.225662,
-    "geom:area_square_m":2782249883.782112,
+    "geom:area_square_m":2782249582.412234,
     "geom:bbox":"113.99879,4.016681,114.817208,4.681249",
     "geom:latitude":4.366613,
     "geom:longitude":114.50171,
@@ -297,14 +297,16 @@
         "gn:id":1820869,
         "gp:id":20069849,
         "hasc:id":"BN.BE",
+        "iso:code":"BN-BE",
         "iso:id":"BN-BE",
         "qs_pg:id":890280,
         "unlc:id":"BN-BE",
         "wd:id":"Q40395",
         "wk:page":"Belait District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BN",
-    "wof:geomhash":"ef23b62720c43821969617e0ad6ca5cb",
+    "wof:geomhash":"5eec6f772dbe40a5233b1eea33c21bea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1690860258,
+    "wof:lastmodified":1695884784,
     "wof:name":"Belait",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/87/85669487.geojson
+++ b/data/856/694/87/85669487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04617,
-    "geom:area_square_m":568804292.806799,
+    "geom:area_square_m":568805283.229595,
     "geom:bbox":"114.73618,4.730585,115.103201,5.057196",
     "geom:latitude":4.900512,
     "geom:longitude":114.897101,
@@ -315,13 +315,15 @@
         "gn:id":1820818,
         "gp:id":20069846,
         "hasc:id":"BN.BM",
+        "iso:code":"BN-BM",
         "iso:id":"BN-BM",
         "qs_pg:id":1084678,
         "unlc:id":"BN-BM",
         "wd:id":"Q153009"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BN",
-    "wof:geomhash":"51107a38cd01d0f86da2bb0020957f8c",
+    "wof:geomhash":"e73f70604417fe4f861325a46fe5ece4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1690860257,
+    "wof:lastmodified":1695884784,
     "wof:name":"Brunei and Muara",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/91/85669491.geojson
+++ b/data/856/694/91/85669491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105858,
-    "geom:area_square_m":1304737541.977541,
+    "geom:area_square_m":1304736355.445822,
     "geom:bbox":"115.022777,4.313769,115.360741,4.90884",
     "geom:latitude":4.595306,
     "geom:longitude":115.166658,
@@ -306,14 +306,16 @@
         "gn:id":1820106,
         "gp:id":20069847,
         "hasc:id":"BN.TE",
+        "iso:code":"BN-TE",
         "iso:id":"BN-TE",
         "qs_pg:id":1085116,
         "unlc:id":"BN-TE",
         "wd:id":"Q263285",
         "wk:page":"Temburong District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BN",
-    "wof:geomhash":"2ecfaf735629b85819fb484155aab5e6",
+    "wof:geomhash":"480ba28ff996004e765cbde0906caeb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1690860258,
+    "wof:lastmodified":1695884483,
     "wof:name":"Temburong",
     "wof:parent_id":85632749,
     "wof:placetype":"region",

--- a/data/856/694/95/85669495.geojson
+++ b/data/856/694/95/85669495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088147,
-    "geom:area_square_m":1086431766.870649,
+    "geom:area_square_m":1086431973.070085,
     "geom:bbox":"114.494444,4.30024,114.847904,4.898766",
     "geom:latitude":4.604446,
     "geom:longitude":114.687965,
@@ -300,14 +300,16 @@
         "gn:id":1820068,
         "gp:id":20069848,
         "hasc:id":"BN.TU",
+        "iso:code":"BN-TU",
         "iso:id":"BN-TU",
         "qs_pg:id":339447,
         "unlc:id":"BN-TU",
         "wd:id":"Q40398",
         "wk:page":"Tutong District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BN",
-    "wof:geomhash":"82b82983880122cb1fcfc141d42024d0",
+    "wof:geomhash":"920dfdad11b0ded7317ae937825d112b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "msa"
     ],
-    "wof:lastmodified":1690860257,
+    "wof:lastmodified":1695884784,
     "wof:name":"Tutong",
     "wof:parent_id":85632749,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.